### PR TITLE
fix: prevent weekly priorities mutation

### DIFF
--- a/src/components/dashboard/WeeklyPriorities.tsx
+++ b/src/components/dashboard/WeeklyPriorities.tsx
@@ -130,7 +130,8 @@ export function WeeklyPriorities({ priorities, onAdd, onToggle, onDelete, onUpda
   }
 
   const filteredAndSortedPriorities = useMemo(() => {
-    let filtered = priorities
+    // Create a shallow copy so sorting doesn't mutate state directly
+    let filtered = [...priorities]
 
     // Apply completion filter
     if (!showCompleted) {


### PR DESCRIPTION
## Summary
- avoid in-place mutation of priorities list when sorting

## Testing
- `npm run lint` *(fails: requires ESLint configuration interaction)*

------
https://chatgpt.com/codex/tasks/task_e_68934ab756a88324a5aa01cbf9e90db3